### PR TITLE
Add Customer Color Palette

### DIFF
--- a/client/cypress/integration/app.spec.ts
+++ b/client/cypress/integration/app.spec.ts
@@ -6,7 +6,7 @@ describe('App', () => {
   beforeEach(() => page.navigateTo());
 
   it('Should have the correct title', () => {
-    page.getAppTitle().should('contain', 'CSCI 3601 Iteration Template');
+    page.getAppTitle().should('contain', 'Handy Pantry');
   });
 
   it('The sidenav should open, navigate to "Users" and back to "Home"', () => {

--- a/client/src/app/app.component.spec.ts
+++ b/client/src/app/app.component.spec.ts
@@ -33,9 +33,9 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'CSCI 3601 Iteration Template'`, () => {
+  it(`should have as title 'Handy Pantry'`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('CSCI 3601 Iteration Template');
+    expect(app.title).toEqual('Handy Pantry');
   });
 });

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -6,5 +6,5 @@ import { Component } from '@angular/core';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  title = 'CSCI 3601 Iteration Template';
+  title = 'Handy Pantry';
 }

--- a/client/src/app/users/user-card.component.html
+++ b/client/src/app/users/user-card.component.html
@@ -10,6 +10,6 @@
     <p>Email: <a href="mailto:{{this.user.email}}" class="user-card-email">{{this.user.email}}</a></p>
   </mat-card-content>
   <mat-card-actions>
-    <button mat-button data-test="viewProfileButton" *ngIf="this.simple" [routerLink]="['/users', this.user._id]">View Profile</button>
+    <button color="primary" mat-raised-button data-test="viewProfileButton" *ngIf="this.simple" [routerLink]="['/users', this.user._id]">View Profile</button>
   </mat-card-actions>
 </mat-card>

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -1,5 +1,6 @@
 // Custom Theming for Angular Material
-@use '@angular/material' as mat;
+@use "@angular/material" as mat;
+$my-primary: mat.define-palette(mat.$indigo-palette, 500);
 // For more information: https://material.angular.io/guide/theming
 // Plus imports for other components in your app.
 
@@ -7,7 +8,6 @@
 // have to load a single css file for Angular Material in your app.
 // Be sure that you only ever include this mixin once!
 @include mat.core();
-
 
 // This is to be able to theme parts of the app dynamically depending on theme (right now: light or dark)
 // You can put styles in this mixin and the theme variables will refer to the actual theme being used (light or dark)
@@ -31,7 +31,10 @@
     }
   }
   .drawer-list-item-active {
-    background-color: change-color(mat.get-color-from-palette($primary), $alpha: 0.15) !important;
+    background-color: change-color(
+      mat.get-color-from-palette($primary),
+      $alpha: 0.15
+    ) !important;
     color: mat.get-color-from-palette($primary) !important;
     .mat-list-icon {
       color: mat.get-color-from-palette($primary) !important;
@@ -50,26 +53,31 @@
 // (imported above). For each palette, you can optionally specify a default, lighter, and darker
 // hue. Available color palettes: https://material.io/design/color/
 
-$light-primary: mat.define-palette(mat.$indigo-palette, 500); // 500 is the base hue of a Material color
+$light-primary: mat.define-palette(mat.$purple-palette, 700); // 500 is the base hue of a Material color
 
- // The 200 here makes the indigo color lighter
- // Material Design dark themes should use a desaturated versions of primary and accent colors
- // See: https://material.io/design/color/dark-theme.html
-$dark-primary: mat.define-palette(mat.$indigo-palette, 200);
+// The 200 here makes the indigo color lighter
+// Material Design dark themes should use a desaturated versions of primary and accent colors
+// See: https://material.io/design/color/dark-theme.html
+$dark-primary: mat.define-palette(mat.$purple-palette, 500);
 
-$light-accent: mat.define-palette(mat.$pink-palette, A200);
-$dark-accent: mat.define-palette(mat.$pink-palette, A100);
+$light-accent: mat.define-palette(mat.$orange-palette, 500);
+$dark-accent: mat.define-palette(mat.$orange-palette, 700);
 
 // The warn palette is optional (defaults to red).
-$light-warn: mat.define-palette(mat.$red-palette); // Without a hue given, it defaults to 500
+$light-warn: mat.define-palette(
+  mat.$red-palette
+); // Without a hue given, it defaults to 500
 $dark-warn: mat.define-palette(mat.$red-palette, 300);
 
 // Create the theme object for a light theme (a Sass map containing all of the palettes).
-$light-theme: mat.define-light-theme($light-primary, $light-accent, $light-warn);
+$light-theme: mat.define-light-theme(
+  $light-primary,
+  $light-accent,
+  $light-warn
+);
 
 // Create the theme object for a dark theme (a Sass map containing all of the palettes).
 $dark-theme: mat.define-dark-theme($dark-primary, $dark-accent, $dark-warn);
-
 
 // Sets up the theming for built in material components with the light theme
 @include mat.all-component-themes($light-theme);
@@ -77,14 +85,14 @@ $dark-theme: mat.define-dark-theme($dark-primary, $dark-accent, $dark-warn);
 // Sets up theming for our custom components with the light theme
 @include app-theming($light-theme);
 
-html, body {
+html,
+body {
   height: 100%;
 }
 
 body {
   margin: 0;
 }
-
 
 // This media query detects if the user has dark-mode turned on on their OS or browser
 // If you don't want to apply dark theme automatically,


### PR DESCRIPTION
Fixes #27

Add Customer Color Palette using existing [material colors](https://material.io/resources/color/#!/?view.left=0&view.right=0&primary.color=7B1FA2&secondary.color=F57C00)

```
$light-primary: mat.define-palette(mat.$purple-palette, 700);
$dark-primary: mat.define-palette(mat.$purple-palette, 500);
$light-accent: mat.define-palette(mat.$orange-palette, 500);
$dark-accent: mat.define-palette(mat.$orange-palette, 700);
```
